### PR TITLE
💄 ボトムナビゲーションの導入

### DIFF
--- a/components/all/BottomNavi.tsx
+++ b/components/all/BottomNavi.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import BottomNavigation from '@material-ui/core/BottomNavigation';
+import BottomNavigationAction from '@material-ui/core/BottomNavigationAction';
+import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
+import SearchIcon from '@material-ui/icons/Search';
+import SettingsIcon from '@material-ui/icons/Settings';
+import { useRouter } from 'next/router';
+
+const BottomNavi = () => {
+  const router = useRouter();
+  const [value, setValue] = useState(0);
+  return (
+    <div className="fixed bottom-0 sm:hidden">
+      <BottomNavigation
+        value={value}
+        onChange={(event, newValue) => {
+          setValue(newValue);
+          router.push(newValue);
+        }}
+        showLabels
+        className="w-96 max-w-md space-x-4"
+      >
+        <BottomNavigationAction
+          value="library"
+          label="ライブラリ"
+          icon={<LibraryBooksIcon />}
+        />
+        <BottomNavigationAction
+          value="search"
+          label="本を探す"
+          icon={<SearchIcon />}
+        />
+        <BottomNavigationAction
+          value="settings"
+          label="設定"
+          icon={<SettingsIcon />}
+        />
+      </BottomNavigation>
+    </div>
+  );
+};
+
+export default BottomNavi;

--- a/components/lp/Footer.tsx
+++ b/components/lp/Footer.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 const Footer = () => {
   return (
-    <div className="bg-gray-100 py-10">
+    <div className="bg-gray-100 pt-10 pb-16">
       <div className="container">
         <div className="flex justify-center space-x-4">
           <Link href="/terms">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import 'tailwindcss/tailwind.css';
+import BottomNavi from '../components/all/BottomNavi';
 import Footer from '../components/lp/Footer';
 import UserProvider from '../context/userContext';
 
@@ -14,6 +15,7 @@ const MyApp = ({ Component, pageProps }) => {
   return (
     <UserProvider>
       <Component {...pageProps} />
+      <BottomNavi />
       <Footer />
     </UserProvider>
   );


### PR DESCRIPTION
fix #29 
# 概要
ボトムナビゲーションの導入。
伴い、フッターの微調整。
画面遷移方法が少し特殊だった。
現状ライブラリの遷移は「library」にしているが、実際は「library/[id]」になる。
とりあえずは現状でOKとする。