### PR TITLE
🔨 Twitter認証に変更

### DIFF
--- a/components/lp/Header.tsx
+++ b/components/lp/Header.tsx
@@ -5,7 +5,7 @@ import firebase from 'firebase/app';
 
 const Header = () => {
   const login = () => {
-    firebase.auth().signInWithPopup(new firebase.auth.GoogleAuthProvider());
+    firebase.auth().signInWithPopup(new firebase.auth.TwitterAuthProvider());
   };
   const { user, loadingUser } = useUser();
 


### PR DESCRIPTION
fix #41
# 概要
Google認証→Twitter認証に変更。
TwitterのAPI申請が実は通っていたという。。。
てっきり承認通知のメールが来るものばかり思っていた。
無事、Twitterでログインできることを確認。