### PR TITLE
🔨 本の削除処理実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^1.3.0",
         "@heroicons/react": "^1.0.1",
         "@material-ui/core": "^4.11.4",
         "@material-ui/icons": "^4.11.2",
@@ -715,6 +716,18 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
       "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+    },
+    "node_modules/@headlessui/react": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.3.0.tgz",
+      "integrity": "sha512-2gqTO6BQ3Jr8vDX1B67n1gl6MGKTt6DBmR+H0qxwj0gTMnR2+Qpktj8alRWxsZBODyOiBb77QSQpE/6gG3MX4Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
     },
     "node_modules/@heroicons/react": {
       "version": "1.0.1",
@@ -10228,6 +10241,12 @@
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
       "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+    },
+    "@headlessui/react": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.3.0.tgz",
+      "integrity": "sha512-2gqTO6BQ3Jr8vDX1B67n1gl6MGKTt6DBmR+H0qxwj0gTMnR2+Qpktj8alRWxsZBODyOiBb77QSQpE/6gG3MX4Q==",
+      "requires": {}
     },
     "@heroicons/react": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "json-server": "json-server --watch db.json --port 3001"
   },
   "dependencies": {
+    "@headlessui/react": "^1.3.0",
     "@heroicons/react": "^1.0.1",
     "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "^4.11.2",

--- a/pages/library.tsx
+++ b/pages/library.tsx
@@ -3,6 +3,7 @@ import Header from '../components/lp/Header';
 import { BookCard } from '../components/library/BookCard';
 import firebase from 'firebase/app';
 import { useUser } from '../context/userContext';
+import { Toaster } from 'react-hot-toast';
 
 const Library = () => {
   const { user } = useUser();
@@ -50,6 +51,7 @@ const Library = () => {
           </div>
         )}
       </div>
+      <Toaster />
     </div>
   );
 };

--- a/pages/library/[id].tsx
+++ b/pages/library/[id].tsx
@@ -1,15 +1,31 @@
-import React, { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import React, {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useState,
+  Fragment,
+} from 'react';
 import Header from '../../components/lp/Header';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import firebase from 'firebase/app';
 import { useUser } from '../../context/userContext';
 import toast, { Toaster } from 'react-hot-toast';
+import { Dialog, Transition } from '@headlessui/react';
 
 const BookDetail = () => {
   const router = useRouter();
   const { user } = useUser();
   const bookId = router.query.id;
+  // 本削除時のダイアログ表示ステイト
+  const [isOpen, setIsOpen] = useState(false);
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+  const openModal = () => {
+    setIsOpen(true);
+  };
 
   // 本詳細データのステイト;
   const [bookData, setBookData] = useState({
@@ -40,7 +56,22 @@ const BookDetail = () => {
   useEffect(() => {
     getBookData();
   }, []);
-  // 本詳細データの取得
+
+  // 本の削除
+  const deleteBook = () => {
+    user &&
+      firebase
+        .firestore()
+        .doc(`users/${user.uid}/books/${bookId}`)
+        .delete()
+        .then(() => {
+          toast.success('削除しました');
+          router.push('/library');
+        })
+        .catch(() => {
+          console.log('error!!!');
+        });
+  };
 
   // Tweetコメント追加
   const addTweetComment = () => {
@@ -60,7 +91,7 @@ const BookDetail = () => {
         });
   };
   return (
-    <div>
+    <div className="bg-blue-100">
       <Header />
       <div className="container">
         <div className="text-center pt-4">
@@ -106,9 +137,86 @@ const BookDetail = () => {
               ツイートする
             </button>
           </div>
+          <div className="text-right py-4">
+            <a
+              className="opacity-50 underline hover:opacity-30 cursor-pointer"
+              onClick={() => setIsOpen(true)}
+            >
+              ライブラリから削除する
+            </a>
+          </div>
         </form>
       </div>
       <Toaster />
+      <Transition appear show={isOpen} as={Fragment}>
+        <Dialog
+          as="div"
+          className="fixed inset-0 z-10 overflow-y-auto"
+          onClose={closeModal}
+        >
+          <div className="min-h-screen px-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0"
+              enterTo="opacity-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Dialog.Overlay className="fixed inset-0" />
+            </Transition.Child>
+
+            {/* This element is to trick the browser into centering the modal contents. */}
+            <span
+              className="inline-block h-screen align-middle"
+              aria-hidden="true"
+            >
+              &#8203;
+            </span>
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+                <Dialog.Title
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  この本をライブラリから削除しても宜しいですか？
+                </Dialog.Title>
+                <div className="mt-2">
+                  <p className="text-sm text-gray-500">
+                    実行するとツイート文も削除されます。
+                  </p>
+                </div>
+
+                <div className="mt-8 text-right space-x-2">
+                  <button
+                    type="button"
+                    className="inline-flex justify-center px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 border border-transparent rounded-md hover:bg-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500"
+                    onClick={closeModal}
+                  >
+                    キャンセル
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex justify-center px-4 py-2 text-sm font-medium text-red-900 bg-red-100 border border-transparent rounded-md hover:bg-red-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500"
+                    onClick={deleteBook}
+                  >
+                    削除する
+                  </button>
+                </div>
+              </div>
+            </Transition.Child>
+          </div>
+        </Dialog>
+      </Transition>
     </div>
   );
 };


### PR DESCRIPTION
fix #35 
# 概要
本の削除処理実装。
- 本詳細画面に「ライブラリから削除する」ボタン設置
- 上記ボタン押下後にモーダル表示（Headlress UI製）
- モーダルの削除ボタン押下後、Firestoreから本削除後、ライブラリ画面に遷移
- 正常に削除されたらトーストで「削除しました」表示