### PR TITLE
🔨 退会処理（CloudFunctions）の実装

### DIFF
--- a/functions/src/deleteUser-functions.ts
+++ b/functions/src/deleteUser-functions.ts
@@ -1,0 +1,20 @@
+import * as functions from 'firebase-functions';
+import { deleteCollectionByPath } from './utils/firebase-util';
+import * as admin from 'firebase-admin';
+
+const db = admin.firestore();
+
+export const deleteUserAccount = functions
+  .region('asia-northeast1')
+  .auth.user()
+  .onDelete(async (user, _) => {
+    const uid = user.uid;
+
+    //ユーザードキュメント削除
+    db.doc(`users/${uid}`).delete();
+
+    //ライブラリ本削除
+    const deleteAllBooks = deleteCollectionByPath(`users/${uid}/books`); //パスを指定
+
+    return Promise.all([deleteAllBooks]);
+  });

--- a/functions/src/deleteUser.ts
+++ b/functions/src/deleteUser.ts
@@ -1,0 +1,14 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+export const deleteUser = functions
+  .region('asia-northeast1')
+  .https.onCall((data, context) => {
+    if (context.auth?.uid) {
+      return admin.auth().deleteUser(context.auth.uid);
+    }
+    throw new functions.https.HttpsError(
+      'permission-denied',
+      'ログインしていません'
+    );
+  });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,9 +1,5 @@
-import * as functions from "firebase-functions";
-
-// // Start writing Firebase Functions
-// // https://firebase.google.com/docs/functions/typescript
-//
-// export const helloWorld = functions.https.onRequest((request, response) => {
-//   functions.logger.info("Hello logs!", {structuredData: true});
-//   response.send("Hello from Firebase!");
-// });
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+admin.initializeApp(functions.config().firebase);
+export * from './deleteUser';
+export * from './deleteUser-functions';

--- a/functions/src/utils/firebase-util.ts
+++ b/functions/src/utils/firebase-util.ts
@@ -1,0 +1,43 @@
+import * as admin from 'firebase-admin';
+const db = admin.firestore();
+
+export function deleteCollectionByPath(
+  collectionPath: string,
+  batchSize: number = 499 //バッチ処理の上限は500ドキュメント(https://firebase.google.com/docs/firestore/manage-data/transactions)
+) {
+  const collectionRef = db.collection(collectionPath);
+  const query = collectionRef.limit(batchSize);
+
+  return new Promise((resolve, reject) =>
+    deleteQueryBatch(query, batchSize, resolve, reject)
+  );
+}
+
+function deleteQueryBatch(
+  query: FirebaseFirestore.Query<FirebaseFirestore.DocumentData>,
+  batchSize: number,
+  resolve: any,
+  reject: any
+) {
+  query
+    .get()
+    .then((snapshot) => {
+      if (snapshot.size == 0) {
+        return 0;
+      }
+
+      const batch = db.batch();
+      snapshot.docs.forEach((doc) => batch.delete(doc.ref));
+      return batch.commit().then(() => snapshot.size);
+    })
+    .then((numDeleted) => {
+      if (numDeleted === 0) {
+        resolve();
+        return;
+      }
+      process.nextTick(() =>
+        deleteQueryBatch(query, batchSize, resolve, reject)
+      );
+    })
+    .catch(reject);
+}

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -5,6 +5,7 @@ import { useUser } from '../context/userContext';
 import toast, { Toaster } from 'react-hot-toast';
 import { Dialog, Transition } from '@headlessui/react';
 import firebase from 'firebase/app';
+import 'firebase/functions';
 import { useRouter } from 'next/router';
 
 const Settings = () => {
@@ -29,6 +30,7 @@ const Settings = () => {
     callable({})
       .then(() => {
         router.push('/');
+        toast.success('アカウント削除しました');
       })
       .catch(() => {
         console.error('アカウント削除失敗しました！');
@@ -140,6 +142,7 @@ const Settings = () => {
           </div>
         </Dialog>
       </Transition>
+      <Toaster />
     </div>
   );
 };


### PR DESCRIPTION
fix #73 
# 概要
退会処理の実装。
deleteUser：ユーザーのauth削除
deleteAccount：ユーザー削除トリガー。削除されたらユーザーに紐づくfirestore内のライブラリを削除する。